### PR TITLE
Strategien geupdated- pfad wird gespeichert und der nächste Raum bei …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,5 @@ dist
 .tern-port
 
 out/
+/tsconfig-moritz.json
+/run-Moritz.ts

--- a/gitternetz.ts
+++ b/gitternetz.ts
@@ -81,7 +81,13 @@ export class GitterNetz {
     let strE: string = "|"
     let strS: string = " "
     let strB: string = "_"
-    let row = strE
+    let row;
+    
+    if (0 == this.start) {
+      row = " "
+    } else {
+      row = "|"
+    }
     let str = ""
     let swall = "S̲"
     let s = "S"

--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ import {Agent} from "./Agent/AgentenKlasse.js"
 import Spiel from "./spiel.js"
 import {LeftWallStrategy} from "./strategy/LeftWallStrategy.js"
 import {AgressivStrategy} from "./strategy/AgressivStrategy.js"
-import {LeftWallStrategyAndMostlyPacifistStrategy} from "./strategy/LeftWallStrategyAndPacifistStrategy.js"
+import {LeftWallStrategyAndMostlyPacifistStrategy} from "./strategy/LeftWallStrategyAndPacifist.js"
 import {RndStrategy} from "./strategy/RndStrategy.js"
 const canvas = document.querySelector('canvas[class="1"') as HTMLCanvasElement;
 canvas.width = 600;

--- a/strategy/AgressivStrategy.ts
+++ b/strategy/AgressivStrategy.ts
@@ -10,7 +10,7 @@ export class AgressivStrategy extends Strategy{
 
       let room_a = super.getRoomFromDirection(pos, a); 
       let room_b = super.getRoomFromDirection(pos, b);;
-      let lastDIrection = super.getDirectionToRoomBeforeFromCoords(pos);
+      let lastDIrection = super.getDirectionToLastVisitedRoom();
       let directionSort = a == lastDIrection ? 1 :( b == lastDIrection ? -1 : (a - b));
       let monsterSort = room_a.monster - room_b.monster;
       let swordSort = room_b.sword - room_a.sword;
@@ -38,7 +38,7 @@ export class AgressivStrategy extends Strategy{
       let roomNum = coordsToRoomNum(super.getCoordsFromDirection(pos, direction), this.breite);
       let room:Room = this.visitedRooms[roomNum][0];
       
-      if(room.monster - ap >= hp){
+      if(room.monster - ap >= hp && room.monster - room.sword >= hp){
         this.visitedRooms[roomNum][2] = Math.max(Visited.Monster_invincible, this.visitedRooms[roomNum][2]);
       }
     }

--- a/strategy/LeftWallStrategy.ts
+++ b/strategy/LeftWallStrategy.ts
@@ -1,5 +1,6 @@
 
 import {Strategy, Direction} from "./Strategy.js"
+import {coordsToRoomNum} from "../utils/CoordConverter.js"
 
 export class LeftWallStrategy extends Strategy{
 
@@ -8,10 +9,8 @@ export class LeftWallStrategy extends Strategy{
     //sollte schon sortiert sein, aber falls sich die reihenfolge ändert, würde es sonst nicht mehr funktionieren
     availableDirections.sort((a, b) => a - b);
     
-    let lastDirection;
     let lastDirInd = -1;
-
-    lastDirection = super.getDirectionToRoomBeforeFromCoords(pos);
+    let lastDirection = super.getDirectionToLastVisitedRoom();
     if(lastDirection != null){
       lastDirInd = availableDirections.indexOf(lastDirection);
     }

--- a/strategy/LeftWallStrategyAndPacifist.ts
+++ b/strategy/LeftWallStrategyAndPacifist.ts
@@ -1,6 +1,7 @@
 
 import {Strategy, Direction, Visited} from "./Strategy.js"
 import {Room} from "../raum.js";
+import { coordsToRoomNum } from "../utils/CoordConverter.js";
 
 export class LeftWallStrategyAndMostlyPacifistStrategy extends Strategy{
   
@@ -9,10 +10,8 @@ export class LeftWallStrategyAndMostlyPacifistStrategy extends Strategy{
     //sollte schon sortiert sein, aber falls sich die reihenfolge ändert, würde es sonst nicht mehr funktionieren
     availableDirections.sort((a, b) => a - b);
     
-    let lastDirection;
     let lastDirInd = -1;
-    
-    lastDirection = super.getDirectionToRoomBeforeFromCoords(pos);
+    let lastDirection = super.getDirectionToLastVisitedRoom();
     if(lastDirection != null){
       lastDirInd = availableDirections.indexOf(lastDirection);
     }
@@ -27,7 +26,7 @@ export class LeftWallStrategyAndMostlyPacifistStrategy extends Strategy{
       let room:Room = this.visitedRooms[roomNum][0];
 
       if(room.monster > 0){
-        if(room.monster - ap >= hp){
+        if(room.monster - ap >= hp && room.monster - room.sword >= hp){
           this.visitedRooms[roomNum][2] = Math.max(Visited.Monster_invincible, this.visitedRooms[roomNum][2]);
         }else{
           this.visitedRooms[roomNum][2] = Math.max(Visited.Monster, this.visitedRooms[roomNum][2]);

--- a/strategy/Strategy.ts
+++ b/strategy/Strategy.ts
@@ -18,6 +18,7 @@ export enum Visited{
 
 export abstract class Strategy{
     protected breite:number;
+    public lastRoomNums:number[] = [];
     protected visitedRooms:[Room, number, Visited][] = new Array<[Room, number, Visited]>();
   
     constructor(breite:number){
@@ -31,6 +32,11 @@ export abstract class Strategy{
     protected abstract orderByPreferences(pos:[number, number], availableDirections:Direction[], hp:number, ap:number):Direction[];
 
     public getNextRoom(pos:[number, number], neighbourRooms:Room[], hp:number, ap:number):Direction{
+        //speichere zu analyseZwecken den Weg ab
+        if(this.lastRoomNums[this.lastRoomNums.length-1] != coordsToRoomNum(pos, this.breite)){ //wenn du in einem neuen raum bist
+            this.lastRoomNums.push(coordsToRoomNum(pos, this.breite));
+        }
+
         //um exceptions zu verhindern und trotzdem damit arbeiten zu können, füge ich die umliegenden Räume in die visited-Liste ein. 
         // Der Startraum wird, falls man in ihm ist, ebenfalls hinzugefügt und nach der ersten Bewegung verlinkt, um Loop, die durch den Startknoten gehen zu erkennen  
         this.registerRooms(pos, neighbourRooms, this.getRoomNums(pos, neighbourRooms));
@@ -56,7 +62,6 @@ export abstract class Strategy{
         
         // wenn wir den neuen Raum zum ersten mal betreten, setzte sein lastroom auf den alten
         this.setLastRoom(pos, nextDirection);
-
         return nextDirection;
     }
 
@@ -192,6 +197,22 @@ export abstract class Strategy{
         return roomNums;
     }
 
+    protected getDirectionToLastVisitedRoom():Direction{
+        let lastRoomNum = this.getLastVisitedRoomNum();
+        if(lastRoomNum != null){
+          return this.getDirectionFromRoomNum(this.lastRoomNums[this.lastRoomNums.length-1], lastRoomNum);
+        }else{
+            return null;
+        }
+    }
+
+    protected getLastVisitedRoomNum():number{
+        if(this.lastRoomNums.length > 1){
+            return this.lastRoomNums[this.lastRoomNums.length-2];
+        }else{
+            return null;
+        }
+    }
 
     protected getVisitedForDirection(pos:[number, number], direction:Direction):Visited{
         let index:number = coordsToRoomNum(this.getCoordsFromDirection(pos, direction), this.breite);
@@ -275,8 +296,7 @@ export abstract class Strategy{
     }
 
     protected getDirectionFromRoomNum(roomNum1:number, roomNum2:number):Direction{
-        let a = this.getDirectionFromCoords(roomNumToCoords(roomNum1, this.breite), roomNumToCoords(roomNum2, this.breite));
-        return a;
+        return this.getDirectionFromCoords(roomNumToCoords(roomNum1, this.breite), roomNumToCoords(roomNum2, this.breite));
     }
 
     protected getDirectionFromCoords(pos1:[number, number], pos2:[number, number]):Direction{


### PR DESCRIPTION
 Strategien geupdated- pfad wird gespeichert und der nächste Raum bei LeftWall und co. wird nur neu aber schöner berechnet. Bugfix bei gitternetz.show; argument hinzugefügt, welches für das erkennen, ob man ein Monster besiegen kann, verantworlich ist